### PR TITLE
Reuse lsp_client work-done-progress types; capture InitializeResult

### DIFF
--- a/isabelle_lsp_client/client.py
+++ b/isabelle_lsp_client/client.py
@@ -26,6 +26,7 @@ from isabelle_lsp_client.protocol import (
     ProgressRequest,
     ProgressToken,
     WorkDoneProgressCancelNotification,
+    WorkDoneProgressCancelParams,
 )
 
 from .version import version
@@ -134,5 +135,7 @@ class IsabelleClient(object):
         """
         logger.info(f"Cancelling workDoneProgress for token {token}")
         await self.lspClient.send_notification(
-            WorkDoneProgressCancelNotification(token=token)
+            WorkDoneProgressCancelNotification(
+                params=WorkDoneProgressCancelParams(token=token)
+            )
         )

--- a/isabelle_lsp_client/handler.py
+++ b/isabelle_lsp_client/handler.py
@@ -3,6 +3,9 @@ import time
 from collections import defaultdict
 from typing import Any, Callable
 
+from lsp_client import InitializeResult
+from pydantic import ValidationError
+
 from isabelle_lsp_client.document import Document
 from isabelle_lsp_client.protocol import (
     PROGRESS,
@@ -35,6 +38,9 @@ class ClientHandler:
     # Latest work done progress state, keyed by progress token. Entries are
     # added on a `begin` notification and removed on `end`.
     progress: dict[ProgressToken, WorkDoneProgress]
+    # Server capabilities advertised in the `initialize` response, captured the
+    # first time a response carrying an `InitializeResult` payload arrives.
+    initialize_result: InitializeResult | None
 
     def __init__(self) -> None:
         self.document = None
@@ -43,6 +49,7 @@ class ClientHandler:
         self.on_timeout_callbacks = []
         self.callbacks = defaultdict(list)
         self.progress = {}
+        self.initialize_result = None
 
     def add_document(self, document: Document) -> None:
         self.documents[document.uri] = document
@@ -84,6 +91,23 @@ class ClientHandler:
     async def on_start(self, **kwargs: Any) -> None:
         for callback in self.on_start_callbacks:
             await callback(self.document, **kwargs)
+
+    def _capture_initialize_result(self, result: Any) -> None:
+        """
+        Store the server's ``InitializeResult`` the first time the response to
+        the ``initialize`` request arrives. Responses are dispatched here
+        asynchronously, so the result is recognised by its ``capabilities``
+        field rather than by correlating the request id. Other request results
+        and malformed payloads are ignored.
+        """
+        if self.initialize_result is not None:
+            return
+        if not isinstance(result, dict) or "capabilities" not in result:
+            return
+        try:
+            self.initialize_result = InitializeResult.model_validate(result)
+        except ValidationError as e:
+            logger.warning("Could not parse initialize result: %s", e)
 
     def _track_progress(self, response: dict[Any, Any]) -> None:
         """
@@ -127,6 +151,7 @@ class ClientHandler:
                     response["id"],
                     response.get("result"),
                 )
+                self._capture_initialize_result(response.get("result"))
             return
         else:
             logger.warning("Unrecognised message shape: %s", response)

--- a/isabelle_lsp_client/protocol.py
+++ b/isabelle_lsp_client/protocol.py
@@ -1,7 +1,24 @@
-from typing import Any, Literal, Union
+"""
+Isabelle-specific LSP protocol types.
 
-from lsp_client import BaseNotification, BaseRequest
-from pydantic import BaseModel
+The ``PIDE/*`` request types are Isabelle extensions and are defined here. The
+work done progress payloads and the cancel notification are part of the LSP base
+protocol and are re-exported from :mod:`lsp_client`; only the ``WorkDoneProgress``
+union and the ``parse_work_done_progress`` helper are Isabelle-side conveniences
+layered on top of those spec types.
+"""
+
+from typing import Any, Union
+
+from lsp_client import (
+    BaseRequest,
+    ProgressToken,
+    WorkDoneProgressBegin,
+    WorkDoneProgressCancelNotification,
+    WorkDoneProgressCancelParams,
+    WorkDoneProgressEnd,
+    WorkDoneProgressReport,
+)
 
 # PIDE requests
 
@@ -30,34 +47,6 @@ PROGRESS = "$/progress"
 WORK_DONE_PROGRESS_CREATE = "window/workDoneProgress/create"
 WORK_DONE_PROGRESS_CANCEL = "window/workDoneProgress/cancel"
 
-ProgressToken = Union[int, str]
-
-
-class WorkDoneProgressBegin(BaseModel):
-    """Signals the start of a work done progress reporting."""
-
-    kind: Literal["begin"] = "begin"
-    title: str
-    cancellable: bool | None = None
-    message: str | None = None
-    percentage: int | None = None
-
-
-class WorkDoneProgressReport(BaseModel):
-    """Reports progress of an ongoing work done progress operation."""
-
-    kind: Literal["report"] = "report"
-    cancellable: bool | None = None
-    message: str | None = None
-    percentage: int | None = None
-
-
-class WorkDoneProgressEnd(BaseModel):
-    """Signals the end of a work done progress reporting."""
-
-    kind: Literal["end"] = "end"
-    message: str | None = None
-
 
 WorkDoneProgress = Union[
     WorkDoneProgressBegin, WorkDoneProgressReport, WorkDoneProgressEnd
@@ -81,13 +70,18 @@ def parse_work_done_progress(value: dict | None) -> WorkDoneProgress | None:
     return None
 
 
-class WorkDoneProgressCancelNotification(BaseNotification):
-    """
-    ``window/workDoneProgress/cancel`` — sent by the client to cancel a
-    server-initiated work done progress identified by ``token``.
-    """
-
-    def __init__(self, token: ProgressToken, **kwargs: Any) -> None:
-        super().__init__(
-            method=WORK_DONE_PROGRESS_CANCEL, params={"token": token}, **kwargs
-        )
+__all__ = [
+    "CaretUpdateRequest",
+    "ProgressRequest",
+    "PROGRESS",
+    "WORK_DONE_PROGRESS_CREATE",
+    "WORK_DONE_PROGRESS_CANCEL",
+    "ProgressToken",
+    "WorkDoneProgress",
+    "WorkDoneProgressBegin",
+    "WorkDoneProgressReport",
+    "WorkDoneProgressEnd",
+    "WorkDoneProgressCancelNotification",
+    "WorkDoneProgressCancelParams",
+    "parse_work_done_progress",
+]

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -231,6 +231,49 @@ class TestWorkDoneProgress:
         assert cb.call_args[0][1]["id"] == 7
 
 
+class TestInitializeResult:
+    @pytest.mark.asyncio
+    async def test_initialize_response_is_captured(self, handler):
+        await handler.handle(
+            {
+                "id": 1,
+                "result": {
+                    "capabilities": {"positionEncoding": "utf-16"},
+                    "serverInfo": {"name": "Isabelle", "version": "2024"},
+                },
+            }
+        )
+
+        assert handler.initialize_result is not None
+        assert handler.initialize_result.serverInfo.name == "Isabelle"
+        assert handler.initialize_result.capabilities.positionEncoding == "utf-16"
+
+    @pytest.mark.asyncio
+    async def test_non_initialize_response_is_ignored(self, handler):
+        await handler.handle({"id": 2, "result": {"some": "other-result"}})
+
+        assert handler.initialize_result is None
+
+    @pytest.mark.asyncio
+    async def test_first_initialize_result_wins(self, handler):
+        await handler.handle(
+            {"id": 1, "result": {"capabilities": {}, "serverInfo": {"name": "first"}}}
+        )
+        await handler.handle(
+            {"id": 9, "result": {"capabilities": {}, "serverInfo": {"name": "second"}}}
+        )
+
+        assert handler.initialize_result.serverInfo.name == "first"
+
+    @pytest.mark.asyncio
+    async def test_error_response_does_not_capture(self, handler):
+        await handler.handle(
+            {"id": 1, "error": {"code": -32600, "message": "bad request"}}
+        )
+
+        assert handler.initialize_result is None
+
+
 class TestDocuments:
     def test_add_document_stores_by_uri(self, handler, mock_document):
         handler.add_document(mock_document)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -3,6 +3,7 @@ from isabelle_lsp_client.protocol import (
     ProgressRequest,
     WorkDoneProgressBegin,
     WorkDoneProgressCancelNotification,
+    WorkDoneProgressCancelParams,
     WorkDoneProgressEnd,
     WorkDoneProgressReport,
     parse_work_done_progress,
@@ -73,7 +74,9 @@ def test_parse_work_done_progress_ignores_unknown_payload():
 
 
 def test_work_done_progress_cancel_notification():
-    notification = WorkDoneProgressCancelNotification(token="abc")
+    notification = WorkDoneProgressCancelNotification(
+        params=WorkDoneProgressCancelParams(token="abc")
+    )
 
     assert notification.model_dump(exclude_none=True) == {
         "jsonrpc": "2.0",


### PR DESCRIPTION
## Summary

Reconciles the Isabelle client with the expanded `lsp_client` protocol.

- **De-duplicate work-done-progress types.** `WorkDoneProgressBegin/Report/End` and the cancel notification are LSP base-protocol types now shipped by `lsp_client`, so the local copies in `protocol.py` are removed and re-exported from upstream instead. Only the Isabelle-side `WorkDoneProgress` union and `parse_work_done_progress()` helper stay local (upstream has no equivalent). The public `IsabelleClient.cancel_work_done_progress(token=...)` API is unchanged — internally it now constructs `WorkDoneProgressCancelParams` to match the upstream notification's constructor.
- **Capture the `initialize` response.** The client is fully async, so the initialize result arrives in `ClientHandler.handle()` rather than being returned by `send_request`. The first response carrying a `capabilities` field is parsed into a typed `InitializeResult` and exposed as `handler.initialize_result` (it was previously logged and discarded).

## Dependency

Requires christiankissig/python-lsp-client#12 (exports `ProgressToken`) to be merged first — CI installs `lsp_client` from git master, and `protocol.py` imports `ProgressToken` from the package root.

## Test plan

- `pytest` — 91 passed (4 new tests covering `InitializeResult` capture)
- `ruff check` clean
- `mypy isabelle_lsp_client/` clean

Stacked on `feature/work-done-progress`; retarget to `master` once that branch merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)