### PR TITLE
Reconcile with expanded lsp_client: de-dup work-done-progress, capture InitializeResult, README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+        key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
     - name: Install dependencies
       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,14 @@
    :target: https://github.com/christiankissig/python-isabelle-lsp-client/actions/workflows/ci.yml
    :alt: CI/CD
 
+.. image:: https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue
+   :target: https://www.python.org/
+   :alt: Python versions
+
+.. image:: https://img.shields.io/badge/license-MIT-green
+   :target: https://github.com/christiankissig/python-isabelle-lsp-client/blob/master/LICENSE
+   :alt: License: MIT
+
 python-isabelle-lsp-client
 ==========================
 

--- a/isabelle_lsp_client/client.py
+++ b/isabelle_lsp_client/client.py
@@ -26,6 +26,7 @@ from isabelle_lsp_client.protocol import (
     ProgressRequest,
     ProgressToken,
     WorkDoneProgressCancelNotification,
+    WorkDoneProgressCancelParams,
 )
 
 from .version import version
@@ -134,5 +135,7 @@ class IsabelleClient(object):
         """
         logger.info(f"Cancelling workDoneProgress for token {token}")
         await self.lspClient.send_notification(
-            WorkDoneProgressCancelNotification(token=token)
+            WorkDoneProgressCancelNotification(
+                params=WorkDoneProgressCancelParams(token=token)
+            )
         )

--- a/isabelle_lsp_client/handler.py
+++ b/isabelle_lsp_client/handler.py
@@ -3,6 +3,9 @@ import time
 from collections import defaultdict
 from typing import Any, Callable
 
+from lsp_client import InitializeResult
+from pydantic import ValidationError
+
 from isabelle_lsp_client.document import Document
 from isabelle_lsp_client.protocol import (
     PROGRESS,
@@ -35,6 +38,9 @@ class ClientHandler:
     # Latest work done progress state, keyed by progress token. Entries are
     # added on a `begin` notification and removed on `end`.
     progress: dict[ProgressToken, WorkDoneProgress]
+    # Server capabilities advertised in the `initialize` response, captured the
+    # first time a response carrying an `InitializeResult` payload arrives.
+    initialize_result: InitializeResult | None
 
     def __init__(self) -> None:
         self.document = None
@@ -43,6 +49,7 @@ class ClientHandler:
         self.on_timeout_callbacks = []
         self.callbacks = defaultdict(list)
         self.progress = {}
+        self.initialize_result = None
 
     def add_document(self, document: Document) -> None:
         self.documents[document.uri] = document
@@ -84,6 +91,23 @@ class ClientHandler:
     async def on_start(self, **kwargs: Any) -> None:
         for callback in self.on_start_callbacks:
             await callback(self.document, **kwargs)
+
+    def _capture_initialize_result(self, result: Any) -> None:
+        """
+        Store the server's ``InitializeResult`` the first time the response to
+        the ``initialize`` request arrives. Responses are dispatched here
+        asynchronously, so the result is recognised by its ``capabilities``
+        field rather than by correlating the request id. Other request results
+        and malformed payloads are ignored.
+        """
+        if self.initialize_result is not None:
+            return
+        if not isinstance(result, dict) or "capabilities" not in result:
+            return
+        try:
+            self.initialize_result = InitializeResult.model_validate(result)
+        except ValidationError as e:
+            logger.warning("Could not parse initialize result: %s", e)
 
     def _track_progress(self, response: dict[Any, Any]) -> None:
         """
@@ -127,6 +151,7 @@ class ClientHandler:
                     response["id"],
                     response.get("result"),
                 )
+                self._capture_initialize_result(response.get("result"))
             return
         else:
             logger.warning("Unrecognised message shape: %s", response)

--- a/isabelle_lsp_client/protocol.py
+++ b/isabelle_lsp_client/protocol.py
@@ -1,7 +1,24 @@
-from typing import Any, Literal, Union
+"""
+Isabelle-specific LSP protocol types.
 
-from lsp_client import BaseNotification, BaseRequest
-from pydantic import BaseModel
+The ``PIDE/*`` request types are Isabelle extensions and are defined here. The
+work done progress payloads and the cancel notification are part of the LSP base
+protocol and are re-exported from :mod:`lsp_client`; only the ``WorkDoneProgress``
+union and the ``parse_work_done_progress`` helper are Isabelle-side conveniences
+layered on top of those spec types.
+"""
+
+from typing import Any, Union
+
+from lsp_client import (
+    BaseRequest,
+    ProgressToken,
+    WorkDoneProgressBegin,
+    WorkDoneProgressCancelNotification,
+    WorkDoneProgressCancelParams,
+    WorkDoneProgressEnd,
+    WorkDoneProgressReport,
+)
 
 # PIDE requests
 
@@ -30,34 +47,6 @@ PROGRESS = "$/progress"
 WORK_DONE_PROGRESS_CREATE = "window/workDoneProgress/create"
 WORK_DONE_PROGRESS_CANCEL = "window/workDoneProgress/cancel"
 
-ProgressToken = Union[int, str]
-
-
-class WorkDoneProgressBegin(BaseModel):
-    """Signals the start of a work done progress reporting."""
-
-    kind: Literal["begin"] = "begin"
-    title: str
-    cancellable: bool | None = None
-    message: str | None = None
-    percentage: int | None = None
-
-
-class WorkDoneProgressReport(BaseModel):
-    """Reports progress of an ongoing work done progress operation."""
-
-    kind: Literal["report"] = "report"
-    cancellable: bool | None = None
-    message: str | None = None
-    percentage: int | None = None
-
-
-class WorkDoneProgressEnd(BaseModel):
-    """Signals the end of a work done progress reporting."""
-
-    kind: Literal["end"] = "end"
-    message: str | None = None
-
 
 WorkDoneProgress = Union[
     WorkDoneProgressBegin, WorkDoneProgressReport, WorkDoneProgressEnd
@@ -81,13 +70,18 @@ def parse_work_done_progress(value: dict | None) -> WorkDoneProgress | None:
     return None
 
 
-class WorkDoneProgressCancelNotification(BaseNotification):
-    """
-    ``window/workDoneProgress/cancel`` — sent by the client to cancel a
-    server-initiated work done progress identified by ``token``.
-    """
-
-    def __init__(self, token: ProgressToken, **kwargs: Any) -> None:
-        super().__init__(
-            method=WORK_DONE_PROGRESS_CANCEL, params={"token": token}, **kwargs
-        )
+__all__ = [
+    "CaretUpdateRequest",
+    "ProgressRequest",
+    "PROGRESS",
+    "WORK_DONE_PROGRESS_CREATE",
+    "WORK_DONE_PROGRESS_CANCEL",
+    "ProgressToken",
+    "WorkDoneProgress",
+    "WorkDoneProgressBegin",
+    "WorkDoneProgressReport",
+    "WorkDoneProgressEnd",
+    "WorkDoneProgressCancelNotification",
+    "WorkDoneProgressCancelParams",
+    "parse_work_done_progress",
+]

--- a/poetry.lock
+++ b/poetry.lock
@@ -663,7 +663,7 @@ pydantic = ">=2.9.0,<3.0.0"
 type = "git"
 url = "https://github.com/christiankissig/python-lsp-client.git"
 reference = "HEAD"
-resolved_reference = "79bcf9557ae11de44143346a3a1cc72f98a6d37e"
+resolved_reference = "634421c4f7477b57b9e67c272d87eefea6a90d26"
 
 [[package]]
 name = "markdown-it-py"

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -231,6 +231,49 @@ class TestWorkDoneProgress:
         assert cb.call_args[0][1]["id"] == 7
 
 
+class TestInitializeResult:
+    @pytest.mark.asyncio
+    async def test_initialize_response_is_captured(self, handler):
+        await handler.handle(
+            {
+                "id": 1,
+                "result": {
+                    "capabilities": {"positionEncoding": "utf-16"},
+                    "serverInfo": {"name": "Isabelle", "version": "2024"},
+                },
+            }
+        )
+
+        assert handler.initialize_result is not None
+        assert handler.initialize_result.serverInfo.name == "Isabelle"
+        assert handler.initialize_result.capabilities.positionEncoding == "utf-16"
+
+    @pytest.mark.asyncio
+    async def test_non_initialize_response_is_ignored(self, handler):
+        await handler.handle({"id": 2, "result": {"some": "other-result"}})
+
+        assert handler.initialize_result is None
+
+    @pytest.mark.asyncio
+    async def test_first_initialize_result_wins(self, handler):
+        await handler.handle(
+            {"id": 1, "result": {"capabilities": {}, "serverInfo": {"name": "first"}}}
+        )
+        await handler.handle(
+            {"id": 9, "result": {"capabilities": {}, "serverInfo": {"name": "second"}}}
+        )
+
+        assert handler.initialize_result.serverInfo.name == "first"
+
+    @pytest.mark.asyncio
+    async def test_error_response_does_not_capture(self, handler):
+        await handler.handle(
+            {"id": 1, "error": {"code": -32600, "message": "bad request"}}
+        )
+
+        assert handler.initialize_result is None
+
+
 class TestDocuments:
     def test_add_document_stores_by_uri(self, handler, mock_document):
         handler.add_document(mock_document)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -3,6 +3,7 @@ from isabelle_lsp_client.protocol import (
     ProgressRequest,
     WorkDoneProgressBegin,
     WorkDoneProgressCancelNotification,
+    WorkDoneProgressCancelParams,
     WorkDoneProgressEnd,
     WorkDoneProgressReport,
     parse_work_done_progress,
@@ -73,7 +74,9 @@ def test_parse_work_done_progress_ignores_unknown_payload():
 
 
 def test_work_done_progress_cancel_notification():
-    notification = WorkDoneProgressCancelNotification(token="abc")
+    notification = WorkDoneProgressCancelNotification(
+        params=WorkDoneProgressCancelParams(token="abc")
+    )
 
     assert notification.model_dump(exclude_none=True) == {
         "jsonrpc": "2.0",


### PR DESCRIPTION
## Summary

Brings `feature/work-done-progress` up to date with the expanded `lsp_client` protocol, plus README polish. The original workDoneProgress implementation already landed on `master` (#2); this PR adds the follow-up reconciliation work on top.

### Protocol refactor (#3)
- **De-duplicate work-done-progress types.** `WorkDoneProgressBegin/Report/End` and the cancel notification are LSP base-protocol types now shipped by `lsp_client`, so the local copies in `protocol.py` are dropped and re-exported from upstream. Only the Isabelle-side `WorkDoneProgress` union and `parse_work_done_progress()` helper remain local. The public `IsabelleClient.cancel_work_done_progress(token=...)` API is unchanged — internally it now builds `WorkDoneProgressCancelParams` to match the upstream constructor.
- **Capture the `initialize` response.** Because the client is fully async, the initialize result arrives in `ClientHandler.handle()` rather than being returned by `send_request`. The first response carrying a `capabilities` field is parsed into a typed `InitializeResult` and exposed as `handler.initialize_result` (previously logged and discarded).

### README
- Add Python version (3.10–3.14) and MIT license badges.

## Dependency

Relies on `christiankissig/python-lsp-client#12` (exports `ProgressToken`), which is **already merged to that repo's master**. CI installs `lsp_client` from git master, so the `ProgressToken` import resolves.

## Test plan

- `pytest` — 91 passed (4 new tests covering `InitializeResult` capture)
- `ruff check` clean
- `mypy isabelle_lsp_client/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)