### PR TITLE
Model PIDE/dynamic_output payloads

### DIFF
--- a/isabelle_lsp_client/__init__.py
+++ b/isabelle_lsp_client/__init__.py
@@ -12,7 +12,15 @@ from isabelle_lsp_client.isabelle import (
     is_sledgehammer_done,
     is_sledgehammer_noproof,
 )
-from isabelle_lsp_client.protocol import CaretUpdateRequest, ProgressRequest
+from isabelle_lsp_client.protocol import (
+    CaretUpdateRequest,
+    DecorationEntry,
+    DecorationRange,
+    DynamicOutput,
+    DynamicOutputDecoration,
+    ProgressRequest,
+    parse_dynamic_output,
+)
 
 from .client import IsabelleClient
 from .document import Document
@@ -24,7 +32,11 @@ __all__ = [
     "__version__",
     "CaretUpdateRequest",
     "ClientHandler",
+    "DecorationEntry",
+    "DecorationRange",
     "Document",
+    "DynamicOutput",
+    "DynamicOutputDecoration",
     "IsabelleClient",
     "IsabelleProcess",
     "PIDE_DECORATION",
@@ -38,4 +50,5 @@ __all__ = [
     "is_isabelle_ready",
     "is_sledgehammer_done",
     "is_sledgehammer_noproof",
+    "parse_dynamic_output",
 ]

--- a/isabelle_lsp_client/handler.py
+++ b/isabelle_lsp_client/handler.py
@@ -10,10 +10,12 @@ from isabelle_lsp_client.document import Document
 from isabelle_lsp_client.protocol import (
     PROGRESS,
     WORK_DONE_PROGRESS_CREATE,
+    DynamicOutput,
     ProgressToken,
     WorkDoneProgress,
     WorkDoneProgressBegin,
     WorkDoneProgressEnd,
+    parse_dynamic_output,
     parse_work_done_progress,
 )
 
@@ -41,6 +43,9 @@ class ClientHandler:
     # Server capabilities advertised in the `initialize` response, captured the
     # first time a response carrying an `InitializeResult` payload arrives.
     initialize_result: InitializeResult | None
+    # Latest PIDE/dynamic_output payload (proof state / output-panel text at the
+    # caret), parsed on each notification.
+    dynamic_output: DynamicOutput | None
 
     def __init__(self) -> None:
         self.document = None
@@ -50,6 +55,7 @@ class ClientHandler:
         self.callbacks = defaultdict(list)
         self.progress = {}
         self.initialize_result = None
+        self.dynamic_output = None
 
     def add_document(self, document: Document) -> None:
         self.documents[document.uri] = document
@@ -131,6 +137,16 @@ class ClientHandler:
             if token in self.progress:
                 self.progress[token] = progress
 
+    def _track_dynamic_output(self, response: dict[Any, Any]) -> None:
+        """
+        Parse and store the latest ``PIDE/dynamic_output`` payload. A malformed
+        payload leaves the previous value in place.
+        """
+        try:
+            self.dynamic_output = parse_dynamic_output(response.get("params"))
+        except ValidationError as e:
+            logger.warning("Could not parse dynamic output: %s", e)
+
     async def handle(self, response: dict[Any, Any]) -> None:
         DOCUMENT_REQUIRED = {PIDE_DECORATION, PIDE_DYNAMIC_OUTPUT}
         DOCUMENT_EXACT = {PIDE_DECORATION}
@@ -172,6 +188,8 @@ class ClientHandler:
 
         if method == PROGRESS:
             self._track_progress(response)
+        elif method == PIDE_DYNAMIC_OUTPUT:
+            self._track_dynamic_output(response)
 
         if self.callbacks.get(method):
             logger.info(f"Handling response for method {method}")

--- a/isabelle_lsp_client/protocol.py
+++ b/isabelle_lsp_client/protocol.py
@@ -6,19 +6,26 @@ work done progress payloads and the cancel notification are part of the LSP base
 protocol and are re-exported from :mod:`lsp_client`; only the ``WorkDoneProgress``
 union and the ``parse_work_done_progress`` helper are Isabelle-side conveniences
 layered on top of those spec types.
+
+The ``PIDE/dynamic_output`` payload (proof state / output-panel text plus typed
+markup) has no published specification; it is defined by the isabelle-emacs
+fork's VSCode server. The models here mirror the observed wire format.
 """
 
 from typing import Any, Union
 
 from lsp_client import (
     BaseRequest,
+    Position,
     ProgressToken,
+    Range,
     WorkDoneProgressBegin,
     WorkDoneProgressCancelNotification,
     WorkDoneProgressCancelParams,
     WorkDoneProgressEnd,
     WorkDoneProgressReport,
 )
+from pydantic import BaseModel, Field, model_validator
 
 # PIDE requests
 
@@ -70,6 +77,109 @@ def parse_work_done_progress(value: dict | None) -> WorkDoneProgress | None:
     return None
 
 
+# PIDE dynamic output
+# https://github.com/m-fleury/isabelle-emacs (VSCode server: Dynamic_Output)
+#
+# `PIDE/dynamic_output` is a server -> client notification carrying the proof
+# state / output-panel text at the current caret, together with typed markup
+# ranges over that text. The `params` shape observed on the wire is:
+#
+#   {"content": "<output text>",
+#    "decorations": [
+#       {"type": "text_keyword1",
+#        "content": [{"range": [start_line, start_char, end_line, end_char]},
+#                    ...]},
+#       ...]}
+#
+# Ranges are 0-based, half-open, and relative to `content` (NOT the source
+# document); lines are split on "\n". `content` may be empty and `decorations`
+# may be absent/empty.
+
+
+class DecorationRange(BaseModel):
+    """
+    A half-open ``[start, end)`` range over the dynamic-output ``content`` text.
+
+    On the wire this is a flat
+    ``[start_line, start_character, end_line, end_character]`` array; it is
+    decoded into named fields here. Lines and characters are 0-based and
+    relative to the ``content`` string.
+    """
+
+    start_line: int
+    start_character: int
+    end_line: int
+    end_character: int
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_array(cls, data: Any) -> Any:
+        if isinstance(data, (list, tuple)):
+            if len(data) != 4:
+                raise ValueError(
+                    f"decoration range must have 4 elements, got {len(data)}"
+                )
+            start_line, start_character, end_line, end_character = data
+            return {
+                "start_line": start_line,
+                "start_character": start_character,
+                "end_line": end_line,
+                "end_character": end_character,
+            }
+        return data
+
+    def to_range(self) -> Range:
+        """Convert to an :class:`lsp_client.Range`."""
+        return Range(
+            start=Position(line=self.start_line, character=self.start_character),
+            end=Position(line=self.end_line, character=self.end_character),
+        )
+
+
+class DecorationEntry(BaseModel):
+    """A single markup span; one entry of a decoration's ``content`` list."""
+
+    range: DecorationRange
+
+
+class DynamicOutputDecoration(BaseModel):
+    """
+    A group of same-typed markup spans within the dynamic-output text.
+
+    ``type`` is an Isabelle rendering class (e.g. ``text_keyword1``,
+    ``text_free``, ``text_bound``, ``text_var``, ``text_main``). The set is open,
+    so it is kept as a plain string rather than an enum.
+    """
+
+    type: str
+    content: list[DecorationEntry] = Field(default_factory=list)
+
+
+class DynamicOutput(BaseModel):
+    """
+    Payload of a ``PIDE/dynamic_output`` notification: the output-panel text at
+    the current caret and the typed markup over it.
+    """
+
+    content: str = ""
+    decorations: list[DynamicOutputDecoration] = Field(default_factory=list)
+
+    @property
+    def lines(self) -> list[str]:
+        """The ``content`` split into lines, matching the decoration indexing."""
+        return self.content.split("\n")
+
+
+def parse_dynamic_output(params: dict | None) -> DynamicOutput | None:
+    """
+    Parse the ``params`` of a ``PIDE/dynamic_output`` notification into a typed
+    :class:`DynamicOutput`, or ``None`` if there is no payload.
+    """
+    if params is None:
+        return None
+    return DynamicOutput.model_validate(params)
+
+
 __all__ = [
     "CaretUpdateRequest",
     "ProgressRequest",
@@ -84,4 +194,9 @@ __all__ = [
     "WorkDoneProgressCancelNotification",
     "WorkDoneProgressCancelParams",
     "parse_work_done_progress",
+    "DecorationRange",
+    "DecorationEntry",
+    "DynamicOutputDecoration",
+    "DynamicOutput",
+    "parse_dynamic_output",
 ]

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -4,12 +4,14 @@ import pytest
 
 from isabelle_lsp_client.handler import (
     PIDE_DECORATION,
+    PIDE_DYNAMIC_OUTPUT,
     WINDOW_LOGMESSAGE,
     ClientHandler,
 )
 from isabelle_lsp_client.protocol import (
     PROGRESS,
     WORK_DONE_PROGRESS_CREATE,
+    DynamicOutput,
     WorkDoneProgressBegin,
     WorkDoneProgressReport,
 )
@@ -229,6 +231,69 @@ class TestWorkDoneProgress:
 
         cb.assert_awaited_once()
         assert cb.call_args[0][1]["id"] == 7
+
+
+class TestDynamicOutput:
+    @pytest.mark.asyncio
+    async def test_dynamic_output_is_parsed_and_tracked(self, handler, mock_document):
+        handler.set_document(mock_document)
+
+        await handler.handle(
+            {
+                "method": PIDE_DYNAMIC_OUTPUT,
+                "params": {
+                    "content": "goal (1 subgoal):",
+                    "decorations": [
+                        {"type": "text_keyword1", "content": [{"range": [0, 0, 0, 4]}]}
+                    ],
+                },
+            }
+        )
+
+        assert isinstance(handler.dynamic_output, DynamicOutput)
+        assert handler.dynamic_output.content == "goal (1 subgoal):"
+        assert handler.dynamic_output.decorations[0].type == "text_keyword1"
+
+    @pytest.mark.asyncio
+    async def test_dynamic_output_callback_still_receives_raw_response(
+        self, handler, mock_document
+    ):
+        handler.set_document(mock_document)
+        cb = AsyncMock()
+        handler.register_on_dynamic_output(cb)
+
+        await handler.handle(
+            {"method": PIDE_DYNAMIC_OUTPUT, "params": {"content": "x"}}
+        )
+
+        cb.assert_awaited_once()
+        # The callback contract is unchanged: raw dict, not the parsed model.
+        assert cb.call_args[0][1]["params"]["content"] == "x"
+
+    @pytest.mark.asyncio
+    async def test_dynamic_output_requires_document(self, handler):
+        with pytest.raises(Exception, match="document not set"):
+            await handler.handle(
+                {"method": PIDE_DYNAMIC_OUTPUT, "params": {"content": "x"}}
+            )
+
+    @pytest.mark.asyncio
+    async def test_malformed_dynamic_output_keeps_previous(
+        self, handler, mock_document
+    ):
+        handler.set_document(mock_document)
+        await handler.handle(
+            {"method": PIDE_DYNAMIC_OUTPUT, "params": {"content": "first"}}
+        )
+        # decorations of the wrong shape must not clobber the tracked value.
+        await handler.handle(
+            {
+                "method": PIDE_DYNAMIC_OUTPUT,
+                "params": {"content": "second", "decorations": [{"range": [0, 0]}]},
+            }
+        )
+
+        assert handler.dynamic_output.content == "first"
 
 
 class TestInitializeResult:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,13 +1,39 @@
+import pytest
+
 from isabelle_lsp_client.protocol import (
     CaretUpdateRequest,
+    DecorationRange,
+    DynamicOutput,
     ProgressRequest,
     WorkDoneProgressBegin,
     WorkDoneProgressCancelNotification,
     WorkDoneProgressCancelParams,
     WorkDoneProgressEnd,
     WorkDoneProgressReport,
+    parse_dynamic_output,
     parse_work_done_progress,
 )
+
+# A real PIDE/dynamic_output payload captured from `isabelle vscode_server`
+# (isabelle-emacs fork). Ranges are [start_line, start_char, end_line, end_char]
+# relative to `content`.
+DYNAMIC_OUTPUT_SAMPLE = {
+    "content": (
+        "proof (prove)\n"
+        "goal (1 subgoal):\n"
+        " 1. \\<forall>x. \\<exists>b. (x, b) \\<in> writes"
+    ),
+    "decorations": [
+        {
+            "type": "text_keyword1",
+            "content": [{"range": [1, 0, 1, 4]}],
+        },
+        {
+            "type": "text_bound",
+            "content": [{"range": [2, 13, 2, 14]}, {"range": [2, 25, 2, 26]}],
+        },
+    ],
+}
 
 
 def test_caret_update_request():
@@ -83,3 +109,55 @@ def test_work_done_progress_cancel_notification():
         "method": "window/workDoneProgress/cancel",
         "params": {"token": "abc"},
     }
+
+
+def test_decoration_range_decodes_flat_array():
+    r = DecorationRange.model_validate([2, 13, 2, 14])
+    assert (r.start_line, r.start_character, r.end_line, r.end_character) == (
+        2,
+        13,
+        2,
+        14,
+    )
+
+
+def test_decoration_range_to_lsp_range():
+    lsp_range = DecorationRange.model_validate([1, 0, 1, 4]).to_range()
+    assert lsp_range.start.line == 1
+    assert lsp_range.start.character == 0
+    assert lsp_range.end.line == 1
+    assert lsp_range.end.character == 4
+
+
+def test_decoration_range_rejects_wrong_arity():
+    with pytest.raises(ValueError):
+        DecorationRange.model_validate([1, 2, 3])
+
+
+def test_parse_dynamic_output_full_payload():
+    out = parse_dynamic_output(DYNAMIC_OUTPUT_SAMPLE)
+
+    assert isinstance(out, DynamicOutput)
+    assert out.content.startswith("proof (prove)")
+    assert out.lines[1] == "goal (1 subgoal):"
+    assert [d.type for d in out.decorations] == ["text_keyword1", "text_bound"]
+    # The keyword decoration covers "goal" on line 1.
+    kw = out.decorations[0].content[0].range
+    assert out.lines[kw.start_line][kw.start_character : kw.end_character] == "goal"
+    # The bound-variable group carries two spans.
+    assert len(out.decorations[1].content) == 2
+
+
+def test_parse_dynamic_output_empty_payload():
+    out = parse_dynamic_output({"content": "", "decorations": []})
+    assert out.content == ""
+    assert out.decorations == []
+    assert out.lines == [""]
+
+
+def test_parse_dynamic_output_defaults_and_none():
+    assert parse_dynamic_output(None) is None
+    # Both fields are optional on the wire.
+    out = parse_dynamic_output({})
+    assert out.content == ""
+    assert out.decorations == []


### PR DESCRIPTION
## Summary

Adds a typed model for `PIDE/dynamic_output` — the server→client notification carrying the proof state / output-panel text at the current caret, together with typed markup ranges over that text.

There is no published specification (the message is defined in the isabelle-emacs fork's Scala VSCode server), so the schema was derived from a captured `isabelle vscode_server` session and verified against every occurrence in that trace.

### Models (`isabelle_lsp_client/protocol.py`)

```
DynamicOutput { content: str, decorations: [DynamicOutputDecoration] }
  DynamicOutputDecoration { type: str, content: [DecorationEntry] }
    DecorationEntry { range: DecorationRange }
      DecorationRange   # wire: [start_line, start_char, end_line, end_char]
```

- `DecorationRange` decodes the flat 4-int array into named fields (`mode="before"` validator) and offers `.to_range()` → `lsp_client.Range`. Ranges are 0-based, half-open, and **relative to `content`** (not the source document).
- `type` is a plain `str` (open set) — Isabelle emits many rendering classes (`text_keyword1`, `text_free`, `text_bound`, `text_var`, `text_main`, …); an enum would reject valid messages.
- `content` and `decorations` default to empty, matching payloads seen on the wire.
- `DynamicOutput.lines` splits `content` on `\n` to match the decoration line indexing.
- `parse_dynamic_output(params)` mirrors the existing `parse_work_done_progress` helper.

### Handler wiring (non-breaking)

`ClientHandler` parses each notification and stores the latest as `handler.dynamic_output: DynamicOutput | None`, mirroring `_track_progress` / `initialize_result`. A malformed payload logs a warning and leaves the previous value intact. **The callback contract is unchanged** — registered callbacks still receive the raw dict, so existing consumers (e.g. `auto_sledge`) are unaffected; they can opt into the typed model via `handler.dynamic_output` or `parse_dynamic_output(...)`.

## Test plan

- `pytest` — 101 passed (10 new: range decode/`to_range`/arity guard, empty/None/default payloads, handler tracking, callback-contract-unchanged, malformed-keeps-previous)
- `ruff check` / `ruff format --check` / `mypy` clean
- All 16 real `PIDE/dynamic_output` messages from the captured session round-trip through the model

🤖 Generated with [Claude Code](https://claude.com/claude-code)