### PR TITLE
Model PIDE/progress payloads

### DIFF
--- a/isabelle_lsp_client/__init__.py
+++ b/isabelle_lsp_client/__init__.py
@@ -1,6 +1,7 @@
 from isabelle_lsp_client.handler import (
     PIDE_DECORATION,
     PIDE_DYNAMIC_OUTPUT,
+    PIDE_PROGRESS,
     WINDOW_LOGMESSAGE,
     WINDOW_SHOWMESSAGE,
 )
@@ -20,9 +21,12 @@ from isabelle_lsp_client.protocol import (
     DecorationRange,
     DynamicOutput,
     DynamicOutputDecoration,
+    NodeStatus,
+    ProgressNodes,
     ProgressRequest,
     parse_decoration,
     parse_dynamic_output,
+    parse_progress,
 )
 
 from .client import IsabelleClient
@@ -44,8 +48,11 @@ __all__ = [
     "DynamicOutputDecoration",
     "IsabelleClient",
     "IsabelleProcess",
+    "NodeStatus",
     "PIDE_DECORATION",
     "PIDE_DYNAMIC_OUTPUT",
+    "PIDE_PROGRESS",
+    "ProgressNodes",
     "ProgressRequest",
     "WINDOW_LOGMESSAGE",
     "WINDOW_SHOWMESSAGE",
@@ -57,4 +64,5 @@ __all__ = [
     "is_sledgehammer_noproof",
     "parse_decoration",
     "parse_dynamic_output",
+    "parse_progress",
 ]

--- a/isabelle_lsp_client/handler.py
+++ b/isabelle_lsp_client/handler.py
@@ -12,12 +12,14 @@ from isabelle_lsp_client.protocol import (
     WORK_DONE_PROGRESS_CREATE,
     DecorationParams,
     DynamicOutput,
+    ProgressNodes,
     ProgressToken,
     WorkDoneProgress,
     WorkDoneProgressBegin,
     WorkDoneProgressEnd,
     parse_decoration,
     parse_dynamic_output,
+    parse_progress,
     parse_work_done_progress,
 )
 
@@ -26,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 PIDE_DECORATION = "PIDE/decoration"
 PIDE_DYNAMIC_OUTPUT = "PIDE/dynamic_output"
+PIDE_PROGRESS = "PIDE/progress"
 WINDOW_LOGMESSAGE = "window/logMessage"
 WINDOW_SHOWMESSAGE = "window/showMessage"
 
@@ -51,6 +54,9 @@ class ClientHandler:
     # Latest PIDE/decoration payload (typed markup for the main document), parsed
     # on each notification that targets the main document.
     decorations: DecorationParams | None
+    # Latest PIDE/progress payload (per-theory-node processing status). Each
+    # message is a full snapshot, so this holds the most recent one.
+    progress_nodes: ProgressNodes | None
 
     def __init__(self) -> None:
         self.document = None
@@ -62,6 +68,7 @@ class ClientHandler:
         self.initialize_result = None
         self.dynamic_output = None
         self.decorations = None
+        self.progress_nodes = None
 
     def add_document(self, document: Document) -> None:
         self.documents[document.uri] = document
@@ -87,6 +94,14 @@ class ClientHandler:
     def register_on_progress(self, handler_method: Callable) -> None:
         """Register a callback for ``$/progress`` notifications."""
         self.callbacks[PROGRESS].append(handler_method)
+
+    def register_on_pide_progress(self, handler_method: Callable) -> None:
+        """
+        Register a callback for ``PIDE/progress`` notifications (per-theory-node
+        processing status). Distinct from :meth:`register_on_progress`, which is
+        for the LSP ``$/progress`` work-done progress.
+        """
+        self.callbacks[PIDE_PROGRESS].append(handler_method)
 
     def register_on_work_done_progress_create(self, handler_method: Callable) -> None:
         """Register a callback for ``window/workDoneProgress/create`` requests."""
@@ -163,6 +178,16 @@ class ClientHandler:
         except ValidationError as e:
             logger.warning("Could not parse decoration: %s", e)
 
+    def _track_progress_nodes(self, response: dict[Any, Any]) -> None:
+        """
+        Parse and store the latest ``PIDE/progress`` snapshot. A malformed
+        payload leaves the previous value in place.
+        """
+        try:
+            self.progress_nodes = parse_progress(response.get("params"))
+        except ValidationError as e:
+            logger.warning("Could not parse progress: %s", e)
+
     async def handle(self, response: dict[Any, Any]) -> None:
         DOCUMENT_REQUIRED = {PIDE_DECORATION, PIDE_DYNAMIC_OUTPUT}
         DOCUMENT_EXACT = {PIDE_DECORATION}
@@ -210,14 +235,17 @@ class ClientHandler:
             # Reached only after the DOCUMENT_EXACT uri check above, so this
             # decoration targets the main document.
             self._track_decoration(response)
+        elif method == PIDE_PROGRESS:
+            self._track_progress_nodes(response)
 
         if self.callbacks.get(method):
             logger.info(f"Handling response for method {method}")
             for callback in self.callbacks[method]:
                 await callback(self.document, response, timestamp)
-        elif method in (PROGRESS, WORK_DONE_PROGRESS_CREATE):
-            # Known work done progress methods are handled internally even
-            # without a consumer callback registered.
+        elif method in (PROGRESS, WORK_DONE_PROGRESS_CREATE, PIDE_PROGRESS):
+            # Known methods handled internally even without a consumer callback;
+            # PIDE/progress is high-frequency, so a missing callback is not a
+            # warning.
             logger.debug(f"No consumer callback for method {method}")
         else:
             logger.warning(f"Unhandled response for method {method}")

--- a/isabelle_lsp_client/protocol.py
+++ b/isabelle_lsp_client/protocol.py
@@ -25,7 +25,7 @@ from lsp_client import (
     WorkDoneProgressEnd,
     WorkDoneProgressReport,
 )
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 # PIDE requests
 
@@ -227,6 +227,85 @@ def parse_decoration(params: dict | None) -> DecorationParams | None:
     return DecorationParams.model_validate(params)
 
 
+# PIDE progress
+# https://github.com/m-fleury/isabelle-emacs (VSCode server: lsp.scala
+# Progress_Node / Progress_Nodes)
+#
+# `PIDE/progress` is a server -> client notification carrying a full snapshot of
+# per-theory-node processing status. The `params` shape is:
+#
+#   {"nodes-status": [
+#       {"name": "<node>", "unprocessed": int, "running": int, "warned": int,
+#        "failed": int, "finished": int, "initialized": int,
+#        "consolidated": int, "canceled": int, "terminated": int},
+#       ...]}
+#
+# The JSON key is "nodes-status" (hyphenated); it is aliased below. Each snapshot
+# lists every known node, so the latest message fully replaces prior state.
+
+
+class NodeStatus(BaseModel):
+    """
+    Processing status of a single theory node (counters over its commands and
+    node-level lifecycle flags), as reported by ``PIDE/progress``.
+    """
+
+    name: str
+    unprocessed: int = 0
+    running: int = 0
+    warned: int = 0
+    failed: int = 0
+    finished: int = 0
+    initialized: int = 0
+    consolidated: int = 0
+    canceled: int = 0
+    terminated: int = 0
+
+    @property
+    def total(self) -> int:
+        """Number of commands in the node (the five per-command counters)."""
+        return (
+            self.unprocessed + self.running + self.warned + self.failed + self.finished
+        )
+
+    @property
+    def is_finished(self) -> bool:
+        """True when nothing is pending (no unprocessed or running commands)."""
+        return self.unprocessed == 0 and self.running == 0
+
+    @property
+    def percentage(self) -> int:
+        """
+        Percent of commands no longer pending (``finished`` + ``warned`` +
+        ``failed``) over :attr:`total`; ``0`` for an empty node.
+        """
+        if self.total == 0:
+            return 0
+        done = self.finished + self.warned + self.failed
+        return round(100 * done / self.total)
+
+
+class ProgressNodes(BaseModel):
+    """
+    Payload of a ``PIDE/progress`` notification: the processing status of every
+    known theory node.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    nodes_status: list[NodeStatus] = Field(default_factory=list, alias="nodes-status")
+
+
+def parse_progress(params: dict | None) -> ProgressNodes | None:
+    """
+    Parse the ``params`` of a ``PIDE/progress`` notification into a typed
+    :class:`ProgressNodes`, or ``None`` if there is no payload.
+    """
+    if params is None:
+        return None
+    return ProgressNodes.model_validate(params)
+
+
 __all__ = [
     "CaretUpdateRequest",
     "ProgressRequest",
@@ -249,4 +328,7 @@ __all__ = [
     "parse_dynamic_output",
     "DecorationParams",
     "parse_decoration",
+    "NodeStatus",
+    "ProgressNodes",
+    "parse_progress",
 ]

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -5,6 +5,7 @@ import pytest
 from isabelle_lsp_client.handler import (
     PIDE_DECORATION,
     PIDE_DYNAMIC_OUTPUT,
+    PIDE_PROGRESS,
     WINDOW_LOGMESSAGE,
     ClientHandler,
 )
@@ -13,6 +14,7 @@ from isabelle_lsp_client.protocol import (
     WORK_DONE_PROGRESS_CREATE,
     DecorationParams,
     DynamicOutput,
+    ProgressNodes,
     WorkDoneProgressBegin,
     WorkDoneProgressReport,
 )
@@ -355,6 +357,57 @@ class TestDecorationTracking:
         )
 
         assert handler.decorations.entries[0].type == "first"
+
+
+class TestProgressNodesTracking:
+    PARAMS = {
+        "nodes-status": [
+            {"name": "Theory.thy", "unprocessed": 1, "running": 0, "finished": 3}
+        ]
+    }
+
+    @pytest.mark.asyncio
+    async def test_progress_is_parsed_and_tracked(self, handler):
+        await handler.handle({"method": PIDE_PROGRESS, "params": self.PARAMS})
+
+        assert isinstance(handler.progress_nodes, ProgressNodes)
+        assert handler.progress_nodes.nodes_status[0].name == "Theory.thy"
+        assert handler.progress_nodes.nodes_status[0].finished == 3
+
+    @pytest.mark.asyncio
+    async def test_progress_needs_no_document(self, handler):
+        # PIDE/progress is server-wide; it must not require a main document.
+        await handler.handle({"method": PIDE_PROGRESS, "params": self.PARAMS})
+        assert handler.progress_nodes is not None
+
+    @pytest.mark.asyncio
+    async def test_progress_callback_receives_raw_response(self, handler):
+        cb = AsyncMock()
+        handler.register_on_pide_progress(cb)
+
+        await handler.handle({"method": PIDE_PROGRESS, "params": self.PARAMS})
+
+        cb.assert_awaited_once()
+        assert cb.call_args[0][1]["params"] == self.PARAMS
+
+    @pytest.mark.asyncio
+    async def test_progress_without_callback_does_not_warn(self, handler, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            await handler.handle({"method": PIDE_PROGRESS, "params": self.PARAMS})
+
+        assert not any("Unhandled" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_malformed_progress_keeps_previous(self, handler):
+        await handler.handle({"method": PIDE_PROGRESS, "params": self.PARAMS})
+        # A node entry missing the required `name` must not clobber the snapshot.
+        await handler.handle(
+            {"method": PIDE_PROGRESS, "params": {"nodes-status": [{"running": 1}]}}
+        )
+
+        assert handler.progress_nodes.nodes_status[0].name == "Theory.thy"
 
 
 class TestInitializeResult:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -7,6 +7,8 @@ from isabelle_lsp_client.protocol import (
     DecorationRange,
     DynamicOutput,
     DynamicOutputDecoration,
+    NodeStatus,
+    ProgressNodes,
     ProgressRequest,
     WorkDoneProgressBegin,
     WorkDoneProgressCancelNotification,
@@ -15,6 +17,7 @@ from isabelle_lsp_client.protocol import (
     WorkDoneProgressReport,
     parse_decoration,
     parse_dynamic_output,
+    parse_progress,
     parse_work_done_progress,
 )
 
@@ -215,3 +218,77 @@ def test_parse_decoration_defaults_and_none():
 def test_parse_decoration_requires_uri():
     with pytest.raises(ValueError):
         parse_decoration({"entries": []})
+
+
+# A PIDE/progress payload following the isabelle-emacs lsp.scala shape. Note the
+# hyphenated `nodes-status` key.
+PROGRESS_SAMPLE = {
+    "nodes-status": [
+        {
+            "name": "Theory.thy",
+            "unprocessed": 2,
+            "running": 1,
+            "warned": 0,
+            "failed": 0,
+            "finished": 7,
+            "initialized": 1,
+            "consolidated": 0,
+            "canceled": 0,
+            "terminated": 0,
+        },
+        {
+            "name": "Other.thy",
+            "unprocessed": 0,
+            "running": 0,
+            "warned": 1,
+            "failed": 0,
+            "finished": 4,
+            "initialized": 1,
+            "consolidated": 1,
+            "canceled": 0,
+            "terminated": 1,
+        },
+    ]
+}
+
+
+def test_parse_progress_decodes_hyphenated_key():
+    prog = parse_progress(PROGRESS_SAMPLE)
+
+    assert isinstance(prog, ProgressNodes)
+    assert [n.name for n in prog.nodes_status] == ["Theory.thy", "Other.thy"]
+
+
+def test_node_status_derived_metrics():
+    prog = parse_progress(PROGRESS_SAMPLE)
+    theory, other = prog.nodes_status
+
+    # Theory.thy: total = 2+1+0+0+7 = 10; done = finished+warned+failed = 7.
+    assert theory.total == 10
+    assert theory.percentage == 70
+    assert theory.is_finished is False
+
+    # Other.thy: nothing pending, all done.
+    assert other.total == 5
+    assert other.percentage == 100
+    assert other.is_finished is True
+
+
+def test_node_status_empty_node():
+    node = NodeStatus(name="Empty.thy")
+    assert node.total == 0
+    assert node.percentage == 0
+    assert node.is_finished is True
+
+
+def test_progress_nodes_populate_by_field_name():
+    # The field name (not just the wire alias) is accepted.
+    prog = ProgressNodes(nodes_status=[NodeStatus(name="A.thy")])
+    assert prog.nodes_status[0].name == "A.thy"
+
+
+def test_parse_progress_defaults_and_none():
+    assert parse_progress(None) is None
+    # `nodes-status` is optional; counters default to 0.
+    prog = parse_progress({})
+    assert prog.nodes_status == []


### PR DESCRIPTION
## Summary

Adds a typed model for `PIDE/progress` — the server→client notification carrying a full snapshot of per-theory-node processing status — following the same approach as the dynamic-output and decoration models.

The captured session never emitted `PIDE/progress`, so (per the agreed fallback) the schema was taken from the isabelle-emacs VSCode server source rather than the log: [`lsp.scala`](https://github.com/m-fleury/isabelle-emacs/blob/Isabelle2024-vsce/src/Tools/VSCode/src/lsp.scala) `Progress_Node` / `Progress_Nodes`.

### Models (`isabelle_lsp_client/protocol.py`)

```
ProgressNodes { nodes-status: [NodeStatus] }
  NodeStatus { name, unprocessed, running, warned, failed, finished,
               initialized, consolidated, canceled, terminated }
```

- The wire key is hyphenated (`"nodes-status"`); it's exposed as `nodes_status` via a pydantic alias with `populate_by_name` (both spellings accepted).
- All counters are ints defaulting to `0`; `name` is required.
- `NodeStatus` adds derived helpers, each documented precisely:
  - `total` — command count (the five per-command counters)
  - `is_finished` — nothing pending (no unprocessed/running)
  - `percentage` — `finished + warned + failed` over `total` (0 for an empty node)
- `parse_progress(params)` mirrors `parse_dynamic_output` / `parse_decoration`.

### Handler wiring (non-breaking)

`ClientHandler` parses each notification and stores the latest snapshot as `handler.progress_nodes: ProgressNodes | None` (each message is a full snapshot, so it replaces prior state). Adds `register_on_pide_progress` — **distinct from** `register_on_progress`, which is for the LSP `$/progress` work-done progress; the two are easy to confuse, so the docstrings call out the difference.

`PIDE/progress` is server-wide (requires no document) and high-frequency, so it joins `$/progress` / `workDoneProgress/create` as an internally-handled method that does **not** log an "Unhandled" warning when no consumer callback is registered. The callback contract is unchanged — callbacks still receive the raw dict.

New exports: `NodeStatus`, `ProgressNodes`, `parse_progress`, `PIDE_PROGRESS`.

## Test plan

- `pytest` — 118 passed (10 new: hyphenated-key decode, derived metrics, empty node, populate-by-name, defaults/None; handler tracking, no-document, raw-callback, no-warn-without-callback, malformed-keeps-previous)
- `ruff check` / `ruff format --check` / `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)