### PR TITLE
Handle textDocument/publishDiagnostics (closes #1)

### DIFF
--- a/isabelle_lsp_client/__init__.py
+++ b/isabelle_lsp_client/__init__.py
@@ -2,6 +2,7 @@ from isabelle_lsp_client.handler import (
     PIDE_DECORATION,
     PIDE_DYNAMIC_OUTPUT,
     PIDE_PROGRESS,
+    TEXTDOCUMENT_PUBLISHDIAGNOSTICS,
     WINDOW_LOGMESSAGE,
     WINDOW_SHOWMESSAGE,
 )
@@ -19,14 +20,18 @@ from isabelle_lsp_client.protocol import (
     DecorationEntry,
     DecorationParams,
     DecorationRange,
+    Diagnostic,
+    DiagnosticSeverity,
     DynamicOutput,
     DynamicOutputDecoration,
     NodeStatus,
     ProgressNodes,
     ProgressRequest,
+    PublishDiagnosticsParams,
     parse_decoration,
     parse_dynamic_output,
     parse_progress,
+    parse_publish_diagnostics,
 )
 
 from .client import IsabelleClient
@@ -43,6 +48,8 @@ __all__ = [
     "DecorationEntry",
     "DecorationParams",
     "DecorationRange",
+    "Diagnostic",
+    "DiagnosticSeverity",
     "Document",
     "DynamicOutput",
     "DynamicOutputDecoration",
@@ -54,6 +61,8 @@ __all__ = [
     "PIDE_PROGRESS",
     "ProgressNodes",
     "ProgressRequest",
+    "PublishDiagnosticsParams",
+    "TEXTDOCUMENT_PUBLISHDIAGNOSTICS",
     "WINDOW_LOGMESSAGE",
     "WINDOW_SHOWMESSAGE",
     "command_finishes_subgoal",
@@ -65,4 +74,5 @@ __all__ = [
     "parse_decoration",
     "parse_dynamic_output",
     "parse_progress",
+    "parse_publish_diagnostics",
 ]

--- a/isabelle_lsp_client/handler.py
+++ b/isabelle_lsp_client/handler.py
@@ -11,6 +11,7 @@ from isabelle_lsp_client.protocol import (
     PROGRESS,
     WORK_DONE_PROGRESS_CREATE,
     DecorationParams,
+    Diagnostic,
     DynamicOutput,
     ProgressNodes,
     ProgressToken,
@@ -20,6 +21,7 @@ from isabelle_lsp_client.protocol import (
     parse_decoration,
     parse_dynamic_output,
     parse_progress,
+    parse_publish_diagnostics,
     parse_work_done_progress,
 )
 
@@ -29,6 +31,7 @@ logger = logging.getLogger(__name__)
 PIDE_DECORATION = "PIDE/decoration"
 PIDE_DYNAMIC_OUTPUT = "PIDE/dynamic_output"
 PIDE_PROGRESS = "PIDE/progress"
+TEXTDOCUMENT_PUBLISHDIAGNOSTICS = "textDocument/publishDiagnostics"
 WINDOW_LOGMESSAGE = "window/logMessage"
 WINDOW_SHOWMESSAGE = "window/showMessage"
 
@@ -57,6 +60,10 @@ class ClientHandler:
     # Latest PIDE/progress payload (per-theory-node processing status). Each
     # message is a full snapshot, so this holds the most recent one.
     progress_nodes: ProgressNodes | None
+    # Latest published diagnostics per document URI. textDocument/publishDiagnostics
+    # replaces all diagnostics for a URI, so each entry is the current full set
+    # (in publication order). Covers imported theories, not just the main one.
+    diagnostics: dict[str, list[Diagnostic]]
 
     def __init__(self) -> None:
         self.document = None
@@ -69,6 +76,7 @@ class ClientHandler:
         self.dynamic_output = None
         self.decorations = None
         self.progress_nodes = None
+        self.diagnostics = {}
 
     def add_document(self, document: Document) -> None:
         self.documents[document.uri] = document
@@ -102,6 +110,14 @@ class ClientHandler:
         for the LSP ``$/progress`` work-done progress.
         """
         self.callbacks[PIDE_PROGRESS].append(handler_method)
+
+    def register_on_publish_diagnostics(self, handler_method: Callable) -> None:
+        """
+        Register a callback for ``textDocument/publishDiagnostics`` notifications
+        (theory errors and warnings). Callbacks fire in registration order, each
+        after :attr:`diagnostics` has been updated for the notification's URI.
+        """
+        self.callbacks[TEXTDOCUMENT_PUBLISHDIAGNOSTICS].append(handler_method)
 
     def register_on_work_done_progress_create(self, handler_method: Callable) -> None:
         """Register a callback for ``window/workDoneProgress/create`` requests."""
@@ -188,6 +204,20 @@ class ClientHandler:
         except ValidationError as e:
             logger.warning("Could not parse progress: %s", e)
 
+    def _track_diagnostics(self, response: dict[Any, Any]) -> None:
+        """
+        Parse a ``textDocument/publishDiagnostics`` notification and store its
+        diagnostics under the document URI, replacing any previous set. A
+        malformed payload leaves the previous value in place.
+        """
+        try:
+            published = parse_publish_diagnostics(response.get("params"))
+        except ValidationError as e:
+            logger.warning("Could not parse diagnostics: %s", e)
+            return
+        if published is not None:
+            self.diagnostics[published.uri] = published.diagnostics
+
     async def handle(self, response: dict[Any, Any]) -> None:
         DOCUMENT_REQUIRED = {PIDE_DECORATION, PIDE_DYNAMIC_OUTPUT}
         DOCUMENT_EXACT = {PIDE_DECORATION}
@@ -237,15 +267,20 @@ class ClientHandler:
             self._track_decoration(response)
         elif method == PIDE_PROGRESS:
             self._track_progress_nodes(response)
+        elif method == TEXTDOCUMENT_PUBLISHDIAGNOSTICS:
+            self._track_diagnostics(response)
 
         if self.callbacks.get(method):
             logger.info(f"Handling response for method {method}")
             for callback in self.callbacks[method]:
                 await callback(self.document, response, timestamp)
-        elif method in (PROGRESS, WORK_DONE_PROGRESS_CREATE, PIDE_PROGRESS):
-            # Known methods handled internally even without a consumer callback;
-            # PIDE/progress is high-frequency, so a missing callback is not a
-            # warning.
+        elif method in (
+            PROGRESS,
+            WORK_DONE_PROGRESS_CREATE,
+            PIDE_PROGRESS,
+            TEXTDOCUMENT_PUBLISHDIAGNOSTICS,
+        ):
+            # Known methods handled internally even without a consumer callback.
             logger.debug(f"No consumer callback for method {method}")
         else:
             logger.warning(f"Unhandled response for method {method}")

--- a/isabelle_lsp_client/protocol.py
+++ b/isabelle_lsp_client/protocol.py
@@ -16,6 +16,8 @@ from typing import Any, Union
 
 from lsp_client import (
     BaseRequest,
+    Diagnostic,
+    DiagnosticSeverity,
     Position,
     ProgressToken,
     Range,
@@ -306,6 +308,41 @@ def parse_progress(params: dict | None) -> ProgressNodes | None:
     return ProgressNodes.model_validate(params)
 
 
+# Publish diagnostics
+# https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics
+#
+# `textDocument/publishDiagnostics` is a standard LSP server -> client
+# notification. Isabelle uses it to report theory errors (bad imports, undefined
+# facts, ...). The `Diagnostic` / `DiagnosticSeverity` element types are reused
+# from :mod:`lsp_client`; only the notification params are modelled here.
+#
+# Isabelle quirks tolerated by the model: each diagnostic may carry a spurious
+# `jsonrpc` key (ignored), and `severity` is frequently absent even for errors.
+
+
+class PublishDiagnosticsParams(BaseModel):
+    """
+    Payload of a ``textDocument/publishDiagnostics`` notification: the full set
+    of diagnostics for the document identified by ``uri``. Each notification
+    replaces any previously published diagnostics for that ``uri``.
+    """
+
+    uri: str
+    version: int | None = None
+    diagnostics: list[Diagnostic] = Field(default_factory=list)
+
+
+def parse_publish_diagnostics(params: dict | None) -> PublishDiagnosticsParams | None:
+    """
+    Parse the ``params`` of a ``textDocument/publishDiagnostics`` notification
+    into a typed :class:`PublishDiagnosticsParams`, or ``None`` if there is no
+    payload. Diagnostic order is preserved.
+    """
+    if params is None:
+        return None
+    return PublishDiagnosticsParams.model_validate(params)
+
+
 __all__ = [
     "CaretUpdateRequest",
     "ProgressRequest",
@@ -331,4 +368,8 @@ __all__ = [
     "NodeStatus",
     "ProgressNodes",
     "parse_progress",
+    "Diagnostic",
+    "DiagnosticSeverity",
+    "PublishDiagnosticsParams",
+    "parse_publish_diagnostics",
 ]

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -6,6 +6,7 @@ from isabelle_lsp_client.handler import (
     PIDE_DECORATION,
     PIDE_DYNAMIC_OUTPUT,
     PIDE_PROGRESS,
+    TEXTDOCUMENT_PUBLISHDIAGNOSTICS,
     WINDOW_LOGMESSAGE,
     ClientHandler,
 )
@@ -408,6 +409,111 @@ class TestProgressNodesTracking:
         )
 
         assert handler.progress_nodes.nodes_status[0].name == "Theory.thy"
+
+
+def _diagnostics(uri, *lines):
+    return {
+        "method": TEXTDOCUMENT_PUBLISHDIAGNOSTICS,
+        "params": {
+            "uri": uri,
+            "diagnostics": [
+                {
+                    "range": {
+                        "start": {"line": line, "character": 0},
+                        "end": {"line": line, "character": 1},
+                    },
+                    "message": f"err {line}",
+                    "severity": 1,
+                }
+                for line in lines
+            ],
+        },
+    }
+
+
+class TestPublishDiagnostics:
+    @pytest.mark.asyncio
+    async def test_diagnostics_held_per_uri(self, handler):
+        await handler.handle(_diagnostics("file:///A.thy", 3, 7))
+
+        held = handler.diagnostics["file:///A.thy"]
+        assert [d.range.start.line for d in held] == [3, 7]
+        assert held[0].message == "err 3"
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_for_imported_theory_needs_no_main_document(
+        self, handler
+    ):
+        # No main document set; diagnostics for an imported theory still land.
+        await handler.handle(_diagnostics("file:///Imported.thy", 1))
+        assert "file:///Imported.thy" in handler.diagnostics
+
+    @pytest.mark.asyncio
+    async def test_republish_replaces_previous_set(self, handler):
+        await handler.handle(_diagnostics("file:///A.thy", 3, 7))
+        await handler.handle(_diagnostics("file:///A.thy", 5))
+
+        assert [d.range.start.line for d in handler.diagnostics["file:///A.thy"]] == [5]
+
+    @pytest.mark.asyncio
+    async def test_cleared_document_stores_empty_list(self, handler):
+        await handler.handle(_diagnostics("file:///A.thy", 3))
+        await handler.handle(_diagnostics("file:///A.thy"))
+
+        assert handler.diagnostics["file:///A.thy"] == []
+
+    @pytest.mark.asyncio
+    async def test_multiple_uris_tracked_independently(self, handler):
+        await handler.handle(_diagnostics("file:///A.thy", 1))
+        await handler.handle(_diagnostics("file:///B.thy", 2, 3))
+
+        assert set(handler.diagnostics) == {"file:///A.thy", "file:///B.thy"}
+        assert len(handler.diagnostics["file:///B.thy"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_callback_runs_after_store_in_registration_order(self, handler):
+        seen = []
+
+        async def cb1(_doc, response, _ts):
+            # The handler store is updated before callbacks fire.
+            uri = response["params"]["uri"]
+            seen.append(("cb1", len(handler.diagnostics[uri])))
+
+        async def cb2(_doc, response, _ts):
+            seen.append(("cb2", None))
+
+        handler.register_on_publish_diagnostics(cb1)
+        handler.register_on_publish_diagnostics(cb2)
+
+        await handler.handle(_diagnostics("file:///A.thy", 1, 2))
+
+        assert [name for name, _ in seen] == ["cb1", "cb2"]
+        assert seen[0] == ("cb1", 2)
+
+    @pytest.mark.asyncio
+    async def test_malformed_diagnostics_keeps_previous(self, handler):
+        await handler.handle(_diagnostics("file:///A.thy", 3))
+        # A diagnostic missing the required `range` must not clobber the set.
+        await handler.handle(
+            {
+                "method": TEXTDOCUMENT_PUBLISHDIAGNOSTICS,
+                "params": {
+                    "uri": "file:///A.thy",
+                    "diagnostics": [{"message": "no range"}],
+                },
+            }
+        )
+
+        assert [d.range.start.line for d in handler.diagnostics["file:///A.thy"]] == [3]
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_without_callback_does_not_warn(self, handler, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            await handler.handle(_diagnostics("file:///A.thy", 1))
+
+        assert not any("Unhandled" in r.message for r in caplog.records)
 
 
 class TestInitializeResult:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -5,11 +5,13 @@ from isabelle_lsp_client.protocol import (
     Decoration,
     DecorationParams,
     DecorationRange,
+    DiagnosticSeverity,
     DynamicOutput,
     DynamicOutputDecoration,
     NodeStatus,
     ProgressNodes,
     ProgressRequest,
+    PublishDiagnosticsParams,
     WorkDoneProgressBegin,
     WorkDoneProgressCancelNotification,
     WorkDoneProgressCancelParams,
@@ -18,6 +20,7 @@ from isabelle_lsp_client.protocol import (
     parse_decoration,
     parse_dynamic_output,
     parse_progress,
+    parse_publish_diagnostics,
     parse_work_done_progress,
 )
 
@@ -292,3 +295,74 @@ def test_parse_progress_defaults_and_none():
     # `nodes-status` is optional; counters default to 0.
     prog = parse_progress({})
     assert prog.nodes_status == []
+
+
+# The bad-theory-import payload from issue #1 (severity set, two errors).
+PUBLISH_DIAGNOSTICS_SAMPLE = {
+    "uri": "file:///path/to/Polylog_Library.thy",
+    "diagnostics": [
+        {
+            "range": {
+                "start": {"line": 7, "character": 2},
+                "end": {"line": 7, "character": 41},
+            },
+            "message": 'Bad theory import "HOL-Complex_Analysis.Complex_Analysis"',
+            "severity": 1,
+        },
+        {
+            "range": {
+                "start": {"line": 8, "character": 2},
+                "end": {"line": 8, "character": 43},
+            },
+            "message": 'Bad theory import "Linear_Recurrences.Eulerian_Polynomials"',
+            "severity": 1,
+        },
+    ],
+}
+
+
+def test_parse_publish_diagnostics_message_severity_position():
+    published = parse_publish_diagnostics(PUBLISH_DIAGNOSTICS_SAMPLE)
+
+    assert isinstance(published, PublishDiagnosticsParams)
+    assert published.uri == "file:///path/to/Polylog_Library.thy"
+    first = published.diagnostics[0]
+    assert first.message.startswith("Bad theory import")
+    assert first.severity == DiagnosticSeverity.Error
+    assert (first.range.start.line, first.range.start.character) == (7, 2)
+
+
+def test_parse_publish_diagnostics_preserves_order():
+    published = parse_publish_diagnostics(PUBLISH_DIAGNOSTICS_SAMPLE)
+    lines = [d.range.start.line for d in published.diagnostics]
+    assert lines == [7, 8]
+
+
+def test_parse_publish_diagnostics_tolerates_isabelle_quirks():
+    # Real Isabelle diagnostics carry a spurious `jsonrpc` key and often omit
+    # `severity` even for errors.
+    published = parse_publish_diagnostics(
+        {
+            "uri": "file:///x.thy",
+            "diagnostics": [
+                {
+                    "jsonrpc": "2.0",
+                    "range": {
+                        "start": {"line": 30, "character": 145},
+                        "end": {"line": 30, "character": 167},
+                    },
+                    "message": 'Undefined fact: "wfs_2_writes_preserved"',
+                }
+            ],
+        }
+    )
+    diag = published.diagnostics[0]
+    assert diag.severity is None
+    assert diag.message.startswith("Undefined fact")
+
+
+def test_parse_publish_diagnostics_defaults_and_none():
+    assert parse_publish_diagnostics(None) is None
+    # A cleared document publishes an empty diagnostics list.
+    published = parse_publish_diagnostics({"uri": "file:///x.thy"})
+    assert published.diagnostics == []


### PR DESCRIPTION
Closes #1.

## Summary

Adds handling for `textDocument/publishDiagnostics`, which Isabelle uses to report theory errors — bad imports, undefined facts, syntax errors. Addresses all four points in the issue:

1. **Model the notification** — `PublishDiagnosticsParams { uri, version?, diagnostics: [Diagnostic] }`, reusing `lsp_client`'s existing `Diagnostic` / `DiagnosticSeverity` element types rather than redefining them.
2. **Parse message, severity, position** — `parse_publish_diagnostics(params)` yields typed `Diagnostic`s with `.message`, `.severity` (→ `DiagnosticSeverity.Error` etc.), and `.range.start.line/.character`.
3. **Available to clients + held in handler** — `ClientHandler.diagnostics: dict[str, list[Diagnostic]]` holds the current set per document URI, plus `register_on_publish_diagnostics(cb)` for push delivery.
4. **Respect order** — diagnostic order within a message is preserved; callbacks fire in registration order, each after `handler.diagnostics` is updated.

### Isabelle-specific handling

- **Imported theories**: the bad-import example in the issue is for a *different* file than the one opened, so diagnostics are stored for **every** URI — not gated on the main document.
- **Replacement semantics**: per the LSP spec, each publish replaces the prior set for that URI (an empty list clears it).
- **Quirks tolerated**: real Isabelle diagnostics carry a spurious per-diagnostic `jsonrpc` key (ignored) and often omit `severity` even for errors (stays `None`) — verified against the captured session.

New exports: `Diagnostic`, `DiagnosticSeverity`, `PublishDiagnosticsParams`, `parse_publish_diagnostics`, `TEXTDOCUMENT_PUBLISHDIAGNOSTICS`.

## Test plan

- `pytest` — 130 passed (12 new: message/severity/position from the issue's payload, order preservation, Isabelle-quirk tolerance, defaults/None; handler per-URI hold, imported-theory-needs-no-main-doc, republish-replaces, clear-stores-empty, multi-URI, callback-after-store-in-order, malformed-keeps-previous, no-warn-without-callback)
- `ruff check` / `ruff format --check` / `mypy` clean
- All 9 real `publishDiagnostics` messages from the captured session drive through `ClientHandler.handle` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)