### PR TITLE
Model PIDE/progress_request as a notification

### DIFF
--- a/isabelle_lsp_client/client.py
+++ b/isabelle_lsp_client/client.py
@@ -114,7 +114,7 @@ class IsabelleClient(object):
         await self.lspClient.send_request(CaretUpdateRequest(uri, line, character))
 
     async def progress_request(self) -> None:
-        await self.lspClient.send_request(ProgressRequest())
+        await self.lspClient.send_notification(ProgressRequest())
 
     async def acknowledge_work_done_progress_create(self, request_id: int) -> None:
         """

--- a/isabelle_lsp_client/protocol.py
+++ b/isabelle_lsp_client/protocol.py
@@ -15,6 +15,7 @@ fork's VSCode server. The models here mirror the observed wire format.
 from typing import Any, Union
 
 from lsp_client import (
+    BaseNotification,
     BaseRequest,
     Diagnostic,
     DiagnosticSeverity,
@@ -39,9 +40,14 @@ class CaretUpdateRequest(BaseRequest):
         super().__init__(method=method, params=params, **kwargs)
 
 
-class ProgressRequest(BaseRequest):
+class ProgressRequest(BaseNotification):
     """
-    Request to update progress of a task.
+    ``PIDE/progress_request`` — asks Isabelle to start emitting ``PIDE/progress``
+    updates.
+
+    Despite the ``_request`` suffix in the method name, this is a JSON-RPC
+    notification: the server reacts by pushing ``PIDE/progress`` notifications
+    rather than returning a response, so it carries no ``id`` and no params.
     """
 
     def __init__(self, **kwargs: Any) -> None:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -62,11 +62,11 @@ def test_caret_update_request():
 
 
 def test_progress_request():
-    request = ProgressRequest(id=1)
+    # PIDE/progress_request is a notification: no id, no params.
+    request = ProgressRequest()
 
     assert request.model_dump(exclude_none=True) == {
         "jsonrpc": "2.0",
-        "id": 1,
         "method": "PIDE/progress_request",
     }
 


### PR DESCRIPTION
## Summary

`PIDE/progress_request` was modeled as a `BaseRequest` (carrying a JSON-RPC `id`), but it is actually a **notification**.

In JSON-RPC/LSP the `id` is about request/response correlation, not message direction — plenty of client→server methods are notifications (`initialized`, `textDocument/didOpen`, `textDocument/didChange`). `PIDE/progress_request` asks Isabelle to *start emitting* `PIDE/progress` updates; the server reacts by pushing `PIDE/progress` notifications rather than returning a response correlated to this message ([isabelle-emacs `lsp.scala` `Progress_Node_Request`](https://github.com/m-fleury/isabelle-emacs/blob/Isabelle2024-vsce/src/Tools/VSCode/src/lsp.scala) matches on the method only and yields `Unit`). So the previously-sent `id` never had a matching response.

## Changes

- `ProgressRequest` now extends `BaseNotification` (no `id`, no params).
- `IsabelleClient.progress_request()` sends it via `send_notification` instead of `send_request`.
- Test updated to assert the notification wire form.

```
before: {"jsonrpc":"2.0","id":N,"method":"PIDE/progress_request","params":null}
after:  {"jsonrpc":"2.0","method":"PIDE/progress_request"}
```

The class name `ProgressRequest` is kept (it represents the `PIDE/progress_request` message, whose method name literally contains `_request`), so the public export is unchanged.

## Test plan

- `pytest` — 130 passed
- `ruff check` / `ruff format --check` / `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)