### PR TITLE
Graceful LSP shutdown + document close/save (closes #10, #11)

### DIFF
--- a/isabelle_lsp_client/client.py
+++ b/isabelle_lsp_client/client.py
@@ -11,12 +11,16 @@ from typing import Any, Optional
 from uuid import uuid4
 
 from lsp_client import (
+    BaseNotification,
     ClientCapabilities,
     ClientInfo,
+    ExitNotification,
     InitializedNotification,
     InitializeParams,
     InitializeRequest,
     LSPClient,
+    ShutdownRequest,
+    TextDocumentDidCloseNotification,
     TextDocumentDidOpenNotification,
     TextDocumentItem,
 )
@@ -108,6 +112,32 @@ class IsabelleClient(object):
             params={"textDocument": text_document_item.model_dump()}
         )
         await self.lspClient.send_notification(notification)
+
+    async def close_text_document(self, uri: str) -> None:
+        """Notify Isabelle that ``uri`` is closed (``textDocument/didClose``)."""
+        notification = TextDocumentDidCloseNotification(
+            params={"textDocument": {"uri": uri}}
+        )
+        await self.lspClient.send_notification(notification)
+
+    async def save_text_document(self, uri: str) -> None:
+        """Notify Isabelle that ``uri`` was saved (``textDocument/didSave``)."""
+        notification = BaseNotification(
+            method="textDocument/didSave", params={"textDocument": {"uri": uri}}
+        )
+        await self.lspClient.send_notification(notification)
+
+    async def shutdown(self) -> None:
+        """
+        Send the LSP ``shutdown`` request. Best-effort during teardown: the
+        response is not awaited, since the read loop is typically already
+        stopping.
+        """
+        await self.lspClient.send_request(ShutdownRequest())
+
+    async def exit(self) -> None:
+        """Send the LSP ``exit`` notification, asking the server to terminate."""
+        await self.lspClient.send_notification(ExitNotification())
 
     async def caret_update(self, uri: str, line: int, character: int) -> None:
         logger.info(f"Sending caret update request: {uri}, {line}, {character}")

--- a/isabelle_lsp_client/document.py
+++ b/isabelle_lsp_client/document.py
@@ -62,6 +62,12 @@ class Document:
             self.uri, self.caret_position[0], self.caret_position[1]
         )
 
+    async def close_file(self) -> None:
+        """
+        Notify Isabelle that this document is closed (``textDocument/didClose``).
+        """
+        await self.isabelle.close_text_document(self.uri)
+
     def write_file(self) -> None:
         """
         Writes the file to disk. Uses output_suffix set at construction time:

--- a/isabelle_lsp_client/process.py
+++ b/isabelle_lsp_client/process.py
@@ -154,6 +154,7 @@ class IsabelleProcess(object):
     async def _shutdown_process(self) -> None:
         if self._process is None or self._process.returncode is not None:
             return
+        await self._graceful_lsp_shutdown()
         if self._process.stdin is not None:
             try:
                 self._process.stdin.close()
@@ -166,6 +167,31 @@ class IsabelleProcess(object):
         except asyncio.TimeoutError:
             self._process.kill()
             await self._process.wait()
+
+    async def _graceful_lsp_shutdown(self) -> None:
+        """
+        Best-effort LSP shutdown handshake before terminating the subprocess:
+        close any open documents, then send ``shutdown`` and ``exit``. The
+        response to ``shutdown`` is not awaited (the read loop has stopped by
+        now). Any failure — e.g. the server already gone — is logged and ignored;
+        the caller terminates the process regardless.
+        """
+        isaClient = getattr(self, "isaClient", None)
+        if isaClient is None:
+            return
+        try:
+            closed: set[str] = set()
+            documents = list(self.clientHandler.documents.values())
+            if self.clientHandler.document is not None:
+                documents.append(self.clientHandler.document)
+            for document in documents:
+                if document.uri not in closed:
+                    closed.add(document.uri)
+                    await document.close_file()
+            await isaClient.shutdown()
+            await isaClient.exit()
+        except Exception as e:
+            logger.debug("Graceful LSP shutdown failed; terminating: %s", e)
 
     async def update_status(
         self, _document: Document, response: dict, _timestamp: str

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -113,6 +113,44 @@ class TestCaretUpdate:
         assert req.params["character"] == 7
 
 
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_close_sends_did_close(self, client, mock_lsp):
+        from lsp_client import TextDocumentDidCloseNotification
+
+        await client.close_text_document(URI)
+
+        notif = mock_lsp.send_notification.call_args[0][0]
+        assert isinstance(notif, TextDocumentDidCloseNotification)
+        assert notif.params["textDocument"]["uri"] == URI
+
+    @pytest.mark.asyncio
+    async def test_save_sends_did_save(self, client, mock_lsp):
+        await client.save_text_document(URI)
+
+        notif = mock_lsp.send_notification.call_args[0][0]
+        assert notif.method == "textDocument/didSave"
+        assert notif.params["textDocument"]["uri"] == URI
+
+    @pytest.mark.asyncio
+    async def test_shutdown_sends_shutdown_request(self, client, mock_lsp):
+        from lsp_client import ShutdownRequest
+
+        await client.shutdown()
+
+        req = mock_lsp.send_request.call_args[0][0]
+        assert isinstance(req, ShutdownRequest)
+
+    @pytest.mark.asyncio
+    async def test_exit_sends_exit_notification(self, client, mock_lsp):
+        from lsp_client import ExitNotification
+
+        await client.exit()
+
+        notif = mock_lsp.send_notification.call_args[0][0]
+        assert isinstance(notif, ExitNotification)
+
+
 class TestWorkDoneProgress:
     @pytest.mark.asyncio
     async def test_acknowledge_create_sends_null_result_response(

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -6,6 +6,80 @@ import pytest
 from isabelle_lsp_client import ClientHandler, IsabelleProcess
 
 
+def _mock_document(uri, calls):
+    doc = MagicMock()
+    doc.uri = uri
+    doc.close_file = AsyncMock(side_effect=lambda: calls.append(f"close:{uri}"))
+    return doc
+
+
+class TestGracefulShutdown:
+    @pytest.fixture
+    def process(self):
+        return IsabelleProcess(ClientHandler())
+
+    def _isa_client(self, calls):
+        isa = MagicMock()
+        isa.shutdown = AsyncMock(side_effect=lambda: calls.append("shutdown"))
+        isa.exit = AsyncMock(side_effect=lambda: calls.append("exit"))
+        return isa
+
+    @pytest.mark.asyncio
+    async def test_closes_documents_then_shutdown_then_exit(self, process):
+        calls = []
+        process.isaClient = self._isa_client(calls)
+        process.clientHandler.add_document(_mock_document("file:///B.thy", calls))
+        process.clientHandler.set_document(_mock_document("file:///A.thy", calls))
+
+        await process._graceful_lsp_shutdown()
+
+        # Documents are closed first, then the shutdown/exit handshake in order.
+        assert calls[-2:] == ["shutdown", "exit"]
+        assert set(calls[:-2]) == {"close:file:///B.thy", "close:file:///A.thy"}
+
+    @pytest.mark.asyncio
+    async def test_each_uri_closed_once(self, process):
+        calls = []
+        process.isaClient = self._isa_client(calls)
+        doc = _mock_document("file:///A.thy", calls)
+        process.clientHandler.add_document(doc)
+        process.clientHandler.set_document(doc)
+
+        await process._graceful_lsp_shutdown()
+
+        assert calls.count("close:file:///A.thy") == 1
+
+    @pytest.mark.asyncio
+    async def test_errors_are_swallowed(self, process):
+        process.isaClient = MagicMock()
+        process.isaClient.shutdown = AsyncMock(side_effect=RuntimeError("gone"))
+        process.isaClient.exit = AsyncMock()
+
+        # Must not raise even though shutdown fails.
+        await process._graceful_lsp_shutdown()
+        process.isaClient.exit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_noop_without_isa_client(self, process):
+        # No isaClient assigned (e.g. startup failed early) — must be a no-op.
+        await process._graceful_lsp_shutdown()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_process_runs_graceful_then_terminates(self, process):
+        process._graceful_lsp_shutdown = AsyncMock()
+        proc = MagicMock()
+        proc.returncode = None
+        proc.stdin = MagicMock()
+        proc.stdin.wait_closed = AsyncMock()
+        proc.wait = AsyncMock()
+        process._process = proc
+
+        await process._shutdown_process()
+
+        process._graceful_lsp_shutdown.assert_awaited_once()
+        proc.terminate.assert_called_once()
+
+
 class TestIsabelleProcessTimeout:
     """Test suite for IsabelleProcess timeout handling in read_loop."""
 


### PR DESCRIPTION
Closes #10. Closes #11.

## Summary

Implements the two lifecycle gaps from the `lsp.scala` audit.

### #10 — Graceful LSP shutdown
`IsabelleProcess` previously closed stdin and SIGTERMed the subprocess. It now performs a best-effort LSP handshake on teardown (`_graceful_lsp_shutdown`): close any open documents, then send `shutdown` and `exit`, before the existing terminate/kill fallback.

- The `shutdown` response is **not awaited** — by teardown the read loop has stopped, and this client has no request/response id correlation. This is intentional best-effort.
- Any failure (e.g. the server already exited) is logged at debug and ignored; the process is terminated regardless.
- `IsabelleClient` gains `shutdown()` / `exit()` over `lsp_client`'s `ShutdownRequest` / `ExitNotification`.

### #11 — Document close/save
The client opened documents (`didOpen`) and edited them (`didChange`) but never closed them. Adds:

- `IsabelleClient.close_text_document(uri)` → `textDocument/didClose` (via `lsp_client.TextDocumentDidCloseNotification`)
- `IsabelleClient.save_text_document(uri)` → `textDocument/didSave`
- `Document.close_file()`

Open documents (main + any added theories, deduped by URI) are closed as part of the graceful shutdown above.

## Test plan

- `pytest` — 139 passed (9 new: client close/save/shutdown/exit; graceful-shutdown ordering, per-URI dedup, error-swallowing, no-isaClient no-op, and `_shutdown_process` invoking the handshake then terminating)
- `ruff check` / `ruff format --check` / `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)