### PR TITLE
Timeout for language-feature methods (part of #14)

### DIFF
--- a/isabelle_lsp_client/client.py
+++ b/isabelle_lsp_client/client.py
@@ -59,6 +59,11 @@ from .version import version
 
 logger = logging.getLogger(__name__)
 
+# Default timeout (seconds) for awaited language-feature requests, so a request
+# Isabelle never answers (e.g. textDocument/documentSymbol) fails fast instead of
+# hanging the caller.
+DEFAULT_LANGUAGE_TIMEOUT = 30.0
+
 
 class IsabelleClient(object):
     """
@@ -177,6 +182,12 @@ class IsabelleClient(object):
     # the single read loop processes one message at a time, so awaiting a
     # response from inside a callback would prevent that response from ever being
     # read.
+    #
+    # Each takes a ``timeout`` (seconds): Isabelle does not answer every request
+    # — notably ``textDocument/documentSymbol`` is not implemented by its
+    # ``vscode_server`` and never replies — so an unbounded wait would hang the
+    # caller. On timeout ``asyncio.TimeoutError`` is raised (and the request is
+    # cancelled). Pass ``timeout=None`` to wait indefinitely.
 
     def _position_params(
         self, uri: str, line: int, character: int
@@ -186,33 +197,56 @@ class IsabelleClient(object):
             position=Position(line=line, character=character),
         )
 
-    async def hover(self, uri: str, line: int, character: int) -> Hover | None:
+    async def hover(
+        self,
+        uri: str,
+        line: int,
+        character: int,
+        timeout: float | None = DEFAULT_LANGUAGE_TIMEOUT,
+    ) -> Hover | None:
         """Request ``textDocument/hover`` at a position; ``None`` if no hover."""
         result = await self.lspClient.request(
-            HoverRequest(params=self._position_params(uri, line, character))
+            HoverRequest(params=self._position_params(uri, line, character)),
+            timeout=timeout,
         )
         return parse_hover_result(result)
 
     async def definition(
-        self, uri: str, line: int, character: int
+        self,
+        uri: str,
+        line: int,
+        character: int,
+        timeout: float | None = DEFAULT_LANGUAGE_TIMEOUT,
     ) -> list[Location] | list[LocationLink] | None:
         """Request ``textDocument/definition`` at a position."""
         result = await self.lspClient.request(
-            DefinitionRequest(params=self._position_params(uri, line, character))
+            DefinitionRequest(params=self._position_params(uri, line, character)),
+            timeout=timeout,
         )
         return parse_definition_result(result)
 
     async def document_highlight(
-        self, uri: str, line: int, character: int
+        self,
+        uri: str,
+        line: int,
+        character: int,
+        timeout: float | None = DEFAULT_LANGUAGE_TIMEOUT,
     ) -> list[DocumentHighlight] | None:
         """Request ``textDocument/documentHighlight`` at a position."""
         result = await self.lspClient.request(
-            DocumentHighlightRequest(params=self._position_params(uri, line, character))
+            DocumentHighlightRequest(
+                params=self._position_params(uri, line, character)
+            ),
+            timeout=timeout,
         )
         return parse_document_highlight_result(result)
 
     async def completion(
-        self, uri: str, line: int, character: int
+        self,
+        uri: str,
+        line: int,
+        character: int,
+        timeout: float | None = DEFAULT_LANGUAGE_TIMEOUT,
     ) -> CompletionList | None:
         """
         Request ``textDocument/completion`` at a position. A bare item array is
@@ -222,15 +256,24 @@ class IsabelleClient(object):
             textDocument=TextDocumentIdentifier(uri=uri),
             position=Position(line=line, character=character),
         )
-        result = await self.lspClient.request(CompletionRequest(params=params))
+        result = await self.lspClient.request(
+            CompletionRequest(params=params), timeout=timeout
+        )
         return parse_completion_result(result)
 
     async def document_symbol(
-        self, uri: str
+        self, uri: str, timeout: float | None = DEFAULT_LANGUAGE_TIMEOUT
     ) -> list[DocumentSymbol] | list[SymbolInformation] | None:
-        """Request ``textDocument/documentSymbol`` for a document (theory outline)."""
+        """
+        Request ``textDocument/documentSymbol`` for a document (theory outline).
+
+        Note: Isabelle's ``vscode_server`` does not currently answer this
+        request, so it will raise ``asyncio.TimeoutError`` after ``timeout``.
+        """
         params = DocumentSymbolParams(textDocument=TextDocumentIdentifier(uri=uri))
-        result = await self.lspClient.request(DocumentSymbolRequest(params=params))
+        result = await self.lspClient.request(
+            DocumentSymbolRequest(params=params), timeout=timeout
+        )
         return parse_document_symbol_result(result)
 
     async def acknowledge_work_done_progress_create(self, request_id: int) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -259,6 +259,20 @@ class TestLanguageFeatures:
         assert isinstance(result[0], DocumentHighlight)
         assert isinstance(mock_lsp.request.call_args[0][0], DocumentHighlightRequest)
 
+    @pytest.mark.asyncio
+    async def test_default_timeout_is_forwarded(self, client, mock_lsp):
+        from isabelle_lsp_client.client import DEFAULT_LANGUAGE_TIMEOUT
+
+        mock_lsp.request.return_value = None
+        await client.hover(URI, 0, 0)
+        assert mock_lsp.request.call_args.kwargs["timeout"] == DEFAULT_LANGUAGE_TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_explicit_timeout_is_forwarded(self, client, mock_lsp):
+        mock_lsp.request.return_value = None
+        await client.document_symbol(URI, timeout=5)
+        assert mock_lsp.request.call_args.kwargs["timeout"] == 5
+
 
 class TestWorkDoneProgress:
     @pytest.mark.asyncio


### PR DESCRIPTION
Part of #14. Surfaced by exercising the merged language-feature methods (#18) against a real Isabelle (isabelle-emacs `Isabelle2025-vsce`).

## Live-testing findings

Driving `IsabelleProcess.run(...)` over a small `Main`-importing theory:

| Feature | Result against real Isabelle |
|---|---|
| `hover` | ✅ works — `MarkedString` content, e.g. `nat` → `type name "Nat.nat"`; `+` → `:: nat \<Rightarrow> nat \<Rightarrow> nat` |
| `definition` | ✅ works — `[Location]` into `…/src/HOL/Nat.thy` |
| `document_highlight` | ✅ responds |
| `completion` | ✅ responds |
| `document_symbol` | ❌ **never replies — hung the caller until the outer timeout** |

`LSPClient.request_timeout` defaults to `None` (wait indefinitely), so the non-responding `documentSymbol` request blocks forever.

## Change

Give `hover` / `definition` / `document_highlight` / `completion` / `document_symbol` a `timeout` parameter (default `30s`, configurable; `None` = wait indefinitely), forwarded to `LSPClient.request`. An unanswered request now raises `asyncio.TimeoutError` (and the request is cancelled via `$/cancelRequest`) instead of hanging. `document_symbol`'s docstring notes it will time out on current Isabelle.

## Test plan

- `pytest` — 162 passed (2 new: default and explicit timeout forwarded)
- `ruff check` / `ruff format --check` / `mypy` clean

## Remaining #14 follow-ups (separate)

- **Symbol decoding**: hover/definition content carries raw Isabelle notation (`\<Rightarrow>`, …) that should be decoded to Unicode — confirmed by the capture above.
- **documentSymbol**: unsupported by Isabelle's `vscode_server`; consider descoping or documenting.
- Unrelated: when the script finishes while idle, `read_loop` stays blocked in `readline` and ignores the done-event, so `run()` only exits on an external timeout — a teardown issue worth its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)